### PR TITLE
Improve rails + docker setup

### DIFF
--- a/blog/Dockerfile
+++ b/blog/Dockerfile
@@ -11,4 +11,4 @@ RUN bundle install
 COPY . .
 
 EXPOSE 3000
-CMD rails server -b 0.0.0.0
+CMD rails server -b 0.0.0.0 -P /tmp/server.pid

--- a/blog/config/environments/development.rb
+++ b/blog/config/environments/development.rb
@@ -50,5 +50,5 @@ Rails.application.configure do
 
   # Use an evented file watcher to asynchronously detect changes in source code,
   # routes, locales, etc. This feature depends on the listen gem.
-  config.file_watcher = ActiveSupport::EventedFileUpdateChecker
+  # config.file_watcher = ActiveSupport::EventedFileUpdateChecker
 end


### PR DESCRIPTION
This commit prevents the issue where you can't restart the container
without getting an error saying the server is already running by
setting the pid file to be outside of the shared volume. Additionally,
windows users weren't seeing their updated files reflected in the running
rails application and this appears to be caused by the evented file system
watcher. Commenting out a line in the development environment allowed
file system changes to be represented in the running application.